### PR TITLE
upgraded docx4j depedency to version 6.0.1

### DIFF
--- a/xlsx-dmn-converter/pom.xml
+++ b/xlsx-dmn-converter/pom.xml
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>org.docx4j</groupId>
       <artifactId>docx4j</artifactId>
-      <version>3.2.2</version>
+      <version>6.0.1</version>
     </dependency>
 
     <dependency>

--- a/xlsx-dmn-converter/src/main/java/org/camunda/bpm/dmn/xlsx/XlsxConverter.java
+++ b/xlsx-dmn-converter/src/main/java/org/camunda/bpm/dmn/xlsx/XlsxConverter.java
@@ -14,18 +14,13 @@ package org.camunda.bpm.dmn.xlsx;
 
 import java.io.InputStream;
 
-import org.apache.fop.fo.properties.Property;
 import org.camunda.bpm.model.dmn.DmnModelInstance;
-import org.docx4j.docProps.core.CoreProperties;
 import org.docx4j.docProps.extended.Properties;
 import org.docx4j.openpackaging.exceptions.Docx4JException;
-import org.docx4j.openpackaging.packages.OpcPackage;
 import org.docx4j.openpackaging.packages.SpreadsheetMLPackage;
 import org.docx4j.openpackaging.parts.SpreadsheetML.SharedStrings;
 import org.docx4j.openpackaging.parts.SpreadsheetML.WorkbookPart;
 import org.docx4j.openpackaging.parts.SpreadsheetML.WorksheetPart;
-import org.xlsx4j.exceptions.Xlsx4jException;
-import org.xlsx4j.sml.Worksheet;
 
 /**
  * @author Thorben Lindhauer
@@ -38,7 +33,7 @@ public class XlsxConverter {
   public DmnModelInstance convert(InputStream inputStream) {
     SpreadsheetMLPackage spreadSheetPackage = null;
     try {
-      spreadSheetPackage = (SpreadsheetMLPackage) SpreadsheetMLPackage.load(inputStream);
+      spreadSheetPackage = SpreadsheetMLPackage.load(inputStream);
     } catch (Docx4JException e) {
       // TODO: checked exception
       throw new RuntimeException("cannot load document", e);


### PR DESCRIPTION
... and removed some unused/obsolete import-Statements.
docx4j version 6.x is announced to continue supporting Java 6 (see
https://www.docx4java.org/forums/announces/docx4j-6-0-1-released-t2715.html)

Addresses
https://github.com/camunda/camunda-dmn-xlsx/issues/9