### PR TITLE
Updated XlsxConverter - Added null check when checking for properties

### DIFF
--- a/xlsx-dmn-converter/src/main/java/org/camunda/bpm/dmn/xlsx/XlsxConverter.java
+++ b/xlsx-dmn-converter/src/main/java/org/camunda/bpm/dmn/xlsx/XlsxConverter.java
@@ -19,6 +19,7 @@ import org.camunda.bpm.model.dmn.DmnModelInstance;
 import org.docx4j.docProps.extended.Properties;
 import org.docx4j.openpackaging.exceptions.Docx4JException;
 import org.docx4j.openpackaging.packages.SpreadsheetMLPackage;
+import org.docx4j.openpackaging.parts.DocPropsExtendedPart;
 import org.docx4j.openpackaging.parts.SpreadsheetML.SharedStrings;
 import org.docx4j.openpackaging.parts.SpreadsheetML.WorkbookPart;
 import org.docx4j.openpackaging.parts.SpreadsheetML.WorksheetPart;
@@ -47,10 +48,10 @@ public class XlsxConverter {
 
     WorksheetPart worksheetPart;
     try {
-      Properties properties = spreadSheetPackage.getDocPropsExtendedPart().getContents();
       String worksheetName;
-      if(properties.getTitlesOfParts() != null) {
-        worksheetName = (String) properties.getTitlesOfParts().getVector().getVariantOrI1OrI2().get(0).getValue();
+      DocPropsExtendedPart docPropsExtendedPart = spreadSheetPackage.getDocPropsExtendedPart();
+      if(docPropsExtendedPart!= null && docPropsExtendedPart.getContents().getTitlesOfParts() != null) {
+        worksheetName = (String) docPropsExtendedPart.getContents().getTitlesOfParts().getVector().getVariantOrI1OrI2().get(0).getValue();
       } else {
         worksheetName = "default";
       }


### PR DESCRIPTION
I was downloading the xlsx file via google spreadsheets.
Getting the same issue - https://github.com/camunda/camunda-dmn-xlsx/issues/26
During debugging, I found that the converter jar is failing when getting the properties, hence giving exception.
File location - https://file.io/fGwIa7